### PR TITLE
Fixed vanish briefly showing a vanished player if they quit while vanished

### DIFF
--- a/src/main/java/org/kitteh/vanish/VanishManager.java
+++ b/src/main/java/org/kitteh/vanish/VanishManager.java
@@ -149,9 +149,6 @@ public final class VanishManager {
         this.resetSleepingIgnored(player);
         VanishPerms.userQuit(player);
         this.removeVanished(player.getName());
-        this.plugin.getServer().getOnlinePlayers().forEach((otherPlayer) -> {
-            otherPlayer.showPlayer(player);
-        });
     }
 
     /**


### PR DESCRIPTION
Basically https://github.com/AddstarMC/VanishNoPacket/commit/8b3645f1aa29604d7b4522f3607fd76172e4fe59

Was added in https://github.com/mbax/VanishNoPacket/commit/38c3989f3dd134c3e924570084fb00f55b06cace but I don't think this is necessary - since player objects aren't reused on reconnects.